### PR TITLE
Refactor paths to use environment variables

### DIFF
--- a/notebooks/eval_model.ipynb
+++ b/notebooks/eval_model.ipynb
@@ -19,8 +19,15 @@
     "import pandas as pd\n",
     "\n",
     "import os\n",
+    "from pathlib import Path\n",
+    "from dotenv import load_dotenv\n",
     "\n",
-    "import DPO_pairwise_human as dp"
+    "import DPO_pairwise_human as dp\n",
+    "\n",
+    "load_dotenv()\n",
+    "PROJECT_ROOT = Path(os.getenv(\"PROJECT_ROOT\")).resolve()\n",
+    "MODEL_ROOT = Path(os.getenv(\"MODEL_ROOT\")).resolve()\n",
+    "DATA_ROOT = Path(os.getenv(\"DATA_ROOT\")).expanduser().resolve()"
    ]
   },
   {
@@ -87,10 +94,10 @@
    ],
    "source": [
     "print(\"loading model and tokenizer...\")\n",
-    "model_path = \"models/test/TinyLlama-1.1B-Chat-v1.0\"\n",
+    "model_path = MODEL_ROOT / 'test' / 'TinyLlama-1.1B-Chat-v1.0'\n",
     "\n",
-    "tokenizer = AutoTokenizer.from_pretrained(model_path)\n",
-    "model = AutoModelForCausalLMWithValueHead.from_pretrained(model_path).to(device)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(str(model_path))\n",
+    "model = AutoModelForCausalLMWithValueHead.from_pretrained(str(model_path)).to(device)\n",
     "model.warnings_issued = {}\n",
     "print(\"model loaded\")"
    ]
@@ -111,14 +118,15 @@
     }
    ],
    "source": [
-    "print(\"loding evaluation dataset...\")\n",
-    "df = pd.read_csv(\"~/.kaggle/cnn_dailymail/validation.csv\", nrows=1)\n",
-    "df = df[[\"article\", \"highlights\"]].rename(columns={\n",
-    "    \"article\": \"content\",\n",
-    "    \"highlights\": \"answer\"\n",
+    "print('loding evaluation dataset...')\n",
+    "dataset_path = DATA_ROOT / '.kaggle' / 'cnn_dailymail' / 'validation.csv'\n",
+    "df = pd.read_csv(dataset_path, nrows=1)\n",
+    "df = df[['article', 'highlights']].rename(columns={\n",
+    "    'article': 'content',\n",
+    "    'highlights': 'answer'\n",
     "})\n",
     "dataset = Dataset.from_pandas(df)\n",
-    "print(\"dataset loaded\")"
+    "print('dataset loaded')"
    ]
   },
   {

--- a/notebooks/test.ipynb
+++ b/notebooks/test.ipynb
@@ -24,6 +24,9 @@
     "from dotenv import load_dotenv\n",
     "\n",
     "load_dotenv()\n",
+    "PROJECT_ROOT = Path(os.getenv('PROJECT_ROOT')).resolve()\n",
+    "MODEL_ROOT = Path(os.getenv('MODEL_ROOT')).resolve()\n",
+    "DATA_ROOT = Path(os.getenv('DATA_ROOT')).expanduser().resolve()\n",
     "\n",
     "import os\n",
     "\n",
@@ -37,9 +40,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-    "# model_path = Path(str(os.getenv(\"MODEL_ROOT\"))).resolve() / 'sft' / 'TinyLlama' / 'TinyLlama-1.1B-Chat-v1.0'\n",
-    "model_path = Path(str(os.getenv(\"MODEL_ROOT\"))).resolve() / 'finetuned' / 'TinyLlama' / 'TinyLlama-1.1B-Chat-v1.0' / 'checkpoint-3'\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "model_path = MODEL_ROOT / 'finetuned' / 'TinyLlama' / 'TinyLlama-1.1B-Chat-v1.0' / 'checkpoint-3'\n",
     "model_path = str(model_path)\n",
     "\n",
     "tokenizer = AutoTokenizer.from_pretrained(model_path)\n",
@@ -54,8 +56,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_path = Path(os.getenv(\"DATA_ROOT\")) / \".kaggle\" / \"cnn_dailymail\"\n",
-    "df = pd.read_csv(str(dataset_path / \"test.csv\"))\n",
+    "dataset_path = DATA_ROOT / '.kaggle' / 'cnn_dailymail'\n",
+    "df = pd.read_csv(str(dataset_path / 'test.csv'))\n",
     "dataset = Dataset.from_pandas(df)"
    ]
   },
@@ -174,7 +176,7 @@
       "<|user|>\n",
       "Summarize the following text in a TL;DR style in one sentence\n",
       "\n",
-      "Ever noticed how plane seats appear to be getting smaller and smaller? With increasing numbers of people taking to the skies, some experts are questioning if having such packed out planes is putting passengers at risk. They say that the shrinking space on aeroplanes is not only uncomfortable - it's putting our health and safety in danger. More than squabbling over the arm rest, shrinking space on planes putting our health and safety in danger? This week, a U.S consumer advisory group set up by the Department of Transportation said at a public hearing that while the government is happy to set standards for animals flying on planes, it doesn't stipulate a minimum amount of space for humans. 'In a world where animals have more rights to space and food than humans,' said Charlie Leocha, consumer representative on the committee. 'It is time that the DOT and FAA take a stand for humane treatment of passengers.' But could crowding on planes lead to more serious issues than fighting for space in the overhead lockers, crashing elbows and seat back kicking? Tests conducted by the FAA use planes with a 31 inch pitch, a standard which on some airlines has decreased . Many economy seats on United Airlines have 30 inches of room, while some airlines offer as little as 28 inches . Cynthia Corbertt, a human factors researcher with the Federal Aviation Administration, that it conducts tests on how quickly passengers can leave a plane. But these tests are conducted using planes with 31 inches between each row of seats, a standard which on some airlines has decreased, reported the Detroit News. The distance between two seats from one point on a seat to the same point on the seat behind it is known as the pitch. While most airlines stick to a pitch of 31 inches or above, some fall below this. While United Airlines has 30 inches of space, Gulf Air economy seats have between 29 and 32 inches, Air Asia offers 29 inches and Spirit Airlines offers just 28 inches. British Airways has a seat pitch of 31 inches, while easyJet has 29 inches, Thomson's short haul seat pitch is 28 inches, and Virgin Atlantic's is 30-31.\n",
+      "Ever noticed how plane seats appear to be getting smaller and smaller? With increasing numbers of people taking to the skies, some experts are questioning if having such packed out planes is putting passengers at risk. They say that the shrinking space on aeroplanes is not only uncomfortable - it's putting our health and safety in danger. More than squabbling over the arm rest, shrinking space on planes putting our health and safety in danger? This week, a U.S consumer advisory group set up by the Department of Transportation said at a public hearing that while the government is happy to set standards for animals flying on planes, it doesn't stipulate a minimum amount of space for humans. 'In a world where animals have more rights to space and food than humans,' said Charlie Leocha, consumer representative on the committee.\u00a0'It is time that the DOT and FAA take a stand for humane treatment of passengers.' But could crowding on planes lead to more serious issues than fighting for space in the overhead lockers, crashing elbows and seat back kicking? Tests conducted by the FAA use planes with a 31 inch pitch, a standard which on some airlines has decreased . Many economy seats on United Airlines have 30 inches of room, while some airlines offer as little as 28 inches . Cynthia Corbertt, a human factors researcher with the Federal Aviation Administration, that it conducts tests on how quickly passengers can leave a plane. But these tests are conducted using planes with 31 inches between each row of seats, a standard which on some airlines has decreased, reported the Detroit News. The distance between two seats from one point on a seat to the same point on the seat behind it is known as the pitch. While most airlines stick to a pitch of 31 inches or above, some fall below this. While United Airlines has 30 inches of space, Gulf Air economy seats have between 29 and 32 inches, Air Asia offers 29 inches and Spirit Airlines offers just 28 inches. British Airways has a seat pitch of 31 inches, while easyJet has 29 inches, Thomson's short haul seat pitch is 28 inches, and Virgin Atlantic's is 30-31.\n",
       " \n",
       "<|assistant|>\n",
       "A U.S. Consumer Advisory Group set up by the Department of Transportation has raised concerns about the shrinking space on aeroplanes, particularly for passengers. The group, which was formed by the Department of Transportation in response to a consumer complaint, has recommended that the government set minimum standards for the amount of space available for humans on planes. The group's report, published in June 2019, stated that while the government is happy to set standards for animals flying on planes, it does not stipulate a minimum amount of space for humans. The group's recommendation is that the DOT and FAA take a stand for humane treatment of passengers by setting minimum standards for the amount of space available for humans on planes. The group's report also highlighted that tests conducted by the FAA use planes with a 31 inch pitch, a standard which has decreased on some airlines. The distance between two seats from one point on a seat to the same point on the seat behind it is known as the pitch. While most airlines stick to a pitch of 31 inches or above, some fall below this. The group's report also raised concerns about the shrinking space on planes, particularly for passengers.\n",

--- a/src/sft/train.py
+++ b/src/sft/train.py
@@ -11,7 +11,14 @@ import os
 import json
 from pathlib import Path
 from dotenv import load_dotenv
+
+from pathlib import Path
+
 load_dotenv()
+
+PROJECT_ROOT = Path(os.getenv("PROJECT_ROOT")).resolve()
+MODEL_ROOT = Path(os.getenv("MODEL_ROOT")).resolve()
+DATA_ROOT = Path(os.getenv("DATA_ROOT")).expanduser().resolve()
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -62,15 +69,16 @@ if __name__ == "__main__":
 
     # load model and tokenizer 
     print("loading model")
-    model_path = Path(str(os.getenv("MODEL_ROOT"))).resolve() / 'sft' / 'TinyLlama' / 'TinyLlama-1.1B-Chat-v1.0'
+    model_path = MODEL_ROOT / 'sft' / 'TinyLlama' / 'TinyLlama-1.1B-Chat-v1.0'
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
-    model = AutoModelForCausalLM.from_pretrained(model_path).to(device)
+    tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+    model = AutoModelForCausalLM.from_pretrained(str(model_path)).to(device)
     model.warnings_issued = {}
     print("model loaded")
 
     print("loading dataet")
-    df = pd.read_csv("~/.kaggle/cnn_dailymail/train.csv", nrows=1000)  # Load subset of dataset
+    dataset_path = DATA_ROOT / '.kaggle' / 'cnn_dailymail' / 'train.csv'
+    df = pd.read_csv(dataset_path, nrows=1000)  # Load subset of dataset
     dataset = Dataset.from_pandas(df)
     print("dataset loaded")
 
@@ -78,7 +86,7 @@ if __name__ == "__main__":
     dataset = preprocess_dataset(dataset, tokenizer)
     print("dataset preprocessed")
 
-    output_dir = Path(str(os.getenv("MODEL_ROOT"))).resolve() / 'finetuned' / 'TinyLlama' / 'TinyLlama-1.1B-Chat-v1.0'
+    output_dir = MODEL_ROOT / 'finetuned' / 'TinyLlama' / 'TinyLlama-1.1B-Chat-v1.0'
 
     training_args = TrainingArguments(
         output_dir=str(output_dir),

--- a/src/utils/visualize.py
+++ b/src/utils/visualize.py
@@ -1,11 +1,17 @@
 from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 import os
+from pathlib import Path
+from dotenv import load_dotenv
 import matplotlib.pyplot as plt
 
+load_dotenv()
+
+PROJECT_ROOT = Path(os.getenv("PROJECT_ROOT")).resolve()
+
 # get the path to the TensorBoard log directory
-log_dir = input("enter path: ")
+log_dir = Path(input("enter path: "))
 event_file = [f for f in os.listdir(log_dir) if f.startswith("events.out")][0]
-event_path = os.path.join(log_dir, event_file)
+event_path = log_dir / event_file
 
 # load the TensorBoard event file
 event_acc = EventAccumulator(event_path)
@@ -33,13 +39,13 @@ def save_fig(tag, event_acc, save_dir):
 
     plt.savefig(save_dir, dpi=300)
 
-graph_dir = "graphs/DPO_pairwise/TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+graph_dir = PROJECT_ROOT / "graphs" / "DPO_pairwise" / "TinyLlama" / "TinyLlama-1.1B-Chat-v1.0"
 os.makedirs(graph_dir, exist_ok=True)
 
 for tag in event_acc.Tags()["scalars"]:
     print(f"Processing tag: {tag}")
-    save_dir = graph_dir + "/" + tag.replace("/", "_") + ".png"
-    save_fig(tag, event_acc, save_dir)
+    save_dir = graph_dir / f"{tag.replace('/', '_')}.png"
+    save_fig(tag, event_acc, str(save_dir))
 
 
 plt.figure(figsize=(10, 5))
@@ -58,4 +64,4 @@ plt.grid(True)
 plt.legend()
 plt.tight_layout()
 
-plt.savefig(graph_dir + "/train_rewards.png", dpi=300)
+plt.savefig(str(graph_dir / "train_rewards.png"), dpi=300)


### PR DESCRIPTION
## Summary
- load `.env` variables in Python scripts and notebooks
- construct paths using `Path(os.getenv(...)).resolve()`
- replace hardcoded dataset and model locations with environment-based paths
- update visualisation script to use `Path`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687dbb6a45f4832ca09d9848e3d71aa4